### PR TITLE
Add CNN-Mamba hybrid model

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ print(f"Average accuracy: {results['avg_accuracy']:.2f}%")
 - **Comprehensive analysis**: Automated visualization and reporting
 - **Reusable**: Clean modular structure for other projects
 - **4-class & 2-class support**: Motor imagery classification (left, right, feet, tongue)
+- **New MambaCCT model**: Combines convolutional tokenization with Mamba sequence modeling (see `test_mamba_cnn.py`)
 
 See `src/README.md` for detailed documentation and `example_usage.py` for complete examples.
 
@@ -78,6 +79,7 @@ Individual notebook files are also available for step-by-step experimentation:
 - `cct_bci2a_stmamba.ipynb` - Main STMambaCCT implementation
 - `cct_bci2a_no_augmentation.ipynb` - Baseline implementation
 - Various experiment notebooks in `cct_experiments/`
+- `test_mamba_cnn.py` - Example script for the new `MambaCCT` model
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ This paper introduces two versions of EEGCCT, an adaptation of the Compact Convo
 * numpy=1.19.5
 * cudatoolkit=11.3.1
 
+### Environment setup
+We recommend creating and activating the provided `eegcct` conda environment
+before running any scripts or notebooks:
+
+```bash
+conda activate eegcct
+```
+
+The environment includes all required Python packages such as `torch`.
+
 ## Datasets:
 The datasets used during the current study are available in the BCI Competition IV repository. The specific datasets used are 2a[1] and 2b[2], which can be accessed at \url{https://www.bbci.de/competition/iv/}.
 

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -4,5 +4,6 @@ from .tiny_eegcct_dw import TinyEEGCCT_DW
 from .mb_performer import MBPerformerEEG
 # from .patch_performer import PatchPerformerEEG  # Temporary commented out due to import issue
 from .stmamba_cct import STMambaCCT, create_stmamba_cct
+from .mamba_cnn import MambaCCT
 
-__all__ = ['CCT', 'MSFAET', 'TinyEEGCCT_DW', 'MBPerformerEEG', 'STMambaCCT', 'create_stmamba_cct']
+__all__ = ['CCT', 'MSFAET', 'TinyEEGCCT_DW', 'MBPerformerEEG', 'STMambaCCT', 'create_stmamba_cct', 'MambaCCT']

--- a/model/mamba_cnn.py
+++ b/model/mamba_cnn.py
@@ -1,0 +1,120 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .cct import Tokenizer
+from .stmamba_cct import MambaBlock
+
+
+class MambaEncoderLayer(nn.Module):
+    """Encoder layer using Mamba block and MLP."""
+    def __init__(self, dim, d_state=16, d_conv=4, expand_factor=2, dropout=0.1):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(dim)
+        self.mamba = MambaBlock(
+            dim=dim,
+            d_state=d_state,
+            d_conv=d_conv,
+            expand_factor=expand_factor,
+        )
+        self.norm2 = nn.LayerNorm(dim)
+        self.mlp = nn.Sequential(
+            nn.Linear(dim, dim * 4),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(dim * 4, dim),
+            nn.Dropout(dropout),
+        )
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x):
+        x = x + self.dropout(self.mamba(self.norm1(x)))
+        x = x + self.dropout(self.mlp(self.norm2(x)))
+        return x
+
+
+class MambaTransformer(nn.Module):
+    """Transformer style stack of Mamba encoder layers."""
+    def __init__(self, dim, num_layers, num_classes, dropout=0.1,
+                 positional_embedding='sine', sequence_length=None,
+                 d_state=16, d_conv=4, expand_factor=2):
+        super().__init__()
+
+        positional_embedding = positional_embedding if positional_embedding in ['sine', 'learnable', 'none'] else 'sine'
+        self.dim = dim
+        self.sequence_length = sequence_length
+
+        assert sequence_length is not None or positional_embedding == 'none', (
+            f"Positional embedding is {positional_embedding} but sequence length not specified")
+
+        self.attention_pool = nn.Linear(dim, 1)
+
+        if positional_embedding != 'none':
+            if positional_embedding == 'learnable':
+                self.positional_emb = nn.Parameter(torch.zeros(1, sequence_length, dim), requires_grad=True)
+            else:
+                self.positional_emb = nn.Parameter(self.sinusoidal_embedding(sequence_length, dim), requires_grad=False)
+        else:
+            self.positional_emb = None
+
+        self.dropout = nn.Dropout(dropout)
+
+        self.blocks = nn.ModuleList([
+            MambaEncoderLayer(dim=dim, d_state=d_state, d_conv=d_conv,
+                               expand_factor=expand_factor, dropout=dropout)
+            for _ in range(num_layers)
+        ])
+        self.norm = nn.LayerNorm(dim)
+        self.fc = nn.Linear(dim, num_classes)
+
+    def forward(self, x):
+        if self.positional_emb is not None:
+            x = x + self.positional_emb
+        x = self.dropout(x)
+        for blk in self.blocks:
+            x = blk(x)
+        x = self.norm(x)
+        x = torch.matmul(F.softmax(self.attention_pool(x), dim=1).transpose(-1, -2), x).squeeze(-2)
+        x = self.fc(x)
+        return x
+
+    @staticmethod
+    def sinusoidal_embedding(n_channels, dim):
+        pe = torch.FloatTensor([[p / (10000 ** (2 * (i // 2) / dim)) for i in range(dim)]
+                                for p in range(n_channels)])
+        pe[:, 0::2] = torch.sin(pe[:, 0::2])
+        pe[:, 1::2] = torch.cos(pe[:, 1::2])
+        return pe.unsqueeze(0)
+
+
+class MambaCCT(nn.Module):
+    """Compact Convolutional Transformer using Mamba blocks."""
+    def __init__(self, kernel_sizes, stride, padding,
+                 pooling_kernel_size, pooling_stride, pooling_padding,
+                 n_conv_layers, n_input_channels, in_planes, activation,
+                 max_pool, conv_bias,
+                 dim, num_layers, num_classes,
+                 dropout=0.1, positional_emb='sine',
+                 d_state=16, d_conv=4, expand_factor=2):
+        super().__init__()
+
+        self.tokenizer = Tokenizer(
+            kernel_sizes=kernel_sizes, stride=stride, padding=padding,
+            pooling_kernel_size=pooling_kernel_size, pooling_stride=pooling_stride, pooling_padding=pooling_padding,
+            n_conv_layers=n_conv_layers, n_input_channels=n_input_channels, n_output_channels=dim,
+            in_planes=in_planes, activation=activation,
+            max_pool=max_pool, conv_bias=conv_bias
+        )
+
+        self.transformer = MambaTransformer(
+            dim=dim, num_layers=num_layers, num_classes=num_classes,
+            dropout=dropout, positional_embedding=positional_emb,
+            sequence_length=self.tokenizer.sequence_length(n_channels=1, height=22, width=1000),
+            d_state=d_state, d_conv=d_conv, expand_factor=expand_factor,
+        )
+
+    def forward(self, x):
+        x = self.tokenizer(x)
+        x = self.transformer(x)
+        return x
+

--- a/test_mamba_cnn.py
+++ b/test_mamba_cnn.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Simple test script for the MambaCCT model"""
+import torch
+import sys
+import os
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+try:
+    from model import MambaCCT
+    print("Successfully imported MambaCCT model")
+except ImportError as e:
+    print("Import error:", e)
+    sys.exit(1)
+
+
+def test_model():
+    """Test the MambaCCT model creation and forward pass"""
+    print("Testing MambaCCT model...")
+
+    try:
+        model = MambaCCT(
+            kernel_sizes=[(22, 1), (1, 24)],
+            stride=(1, 1),
+            padding=(0, 0),
+            pooling_kernel_size=(3, 3),
+            pooling_stride=(1, 1),
+            pooling_padding=(0, 0),
+            n_conv_layers=2,
+            n_input_channels=1,
+            in_planes=64,
+            activation=None,
+            max_pool=False,
+            conv_bias=False,
+            dim=64,
+            num_layers=2,
+            num_classes=4,
+        )
+        print("Model created successfully!")
+    except Exception as e:
+        print("Error creating model:", e)
+        return False
+
+    total_params = sum(p.numel() for p in model.parameters())
+    print("Total parameters:", total_params)
+
+    try:
+        x = torch.randn(2, 1, 22, 1000)
+        print("Input shape:", x.shape)
+        with torch.no_grad():
+            output = model(x)
+        print("Output shape:", output.shape)
+        expected = (2, 4)
+        if output.shape == expected:
+            print("Output shape is correct!")
+            return True
+        else:
+            print("Expected", expected, "got", output.shape)
+            return False
+    except Exception as e:
+        print("Error during forward pass:", e)
+        return False
+
+
+if __name__ == "__main__":
+    success = test_model()
+    if success:
+        print("All tests passed! MambaCCT model is working correctly.")
+    else:
+        print("Tests failed! Please check the model implementation.")
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- implement `MambaCCT` module using CNN tokenizer and Mamba blocks
- export new model in `model/__init__.py`
- provide a simple test script `test_mamba_cnn.py`

## Testing
- `python -m py_compile model/mamba_cnn.py test_mamba_cnn.py`
- `python test_mamba_cnn.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687f3e4a81308330a2a47a31df1040d6