### PR TITLE
Add modular training pipeline for MambaCCT

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ This paper introduces two versions of EEGCCT, an adaptation of the Compact Convo
 * numpy=1.19.5
 * cudatoolkit=11.3.1
 
+### Environment setup
+We recommend creating and activating the provided `eegcct` conda environment
+before running any scripts or notebooks:
+
+```bash
+conda activate eegcct
+```
+
+The environment includes all required Python packages such as `torch`.
+
 ## Datasets:
 The datasets used during the current study are available in the BCI Competition IV repository. The specific datasets used are 2a[1] and 2b[2], which can be accessed at \url{https://www.bbci.de/competition/iv/}.
 
@@ -59,6 +69,7 @@ print(f"Average accuracy: {results['avg_accuracy']:.2f}%")
 - **Comprehensive analysis**: Automated visualization and reporting
 - **Reusable**: Clean modular structure for other projects
 - **4-class & 2-class support**: Motor imagery classification (left, right, feet, tongue)
+- **New MambaCCT model**: Combines convolutional tokenization with Mamba sequence modeling (see `test_mamba_cnn.py`)
 
 See `src/README.md` for detailed documentation and `example_usage.py` for complete examples.
 
@@ -68,16 +79,17 @@ Individual notebook files are also available for step-by-step experimentation:
 - `cct_bci2a_stmamba.ipynb` - Main STMambaCCT implementation
 - `cct_bci2a_no_augmentation.ipynb` - Baseline implementation
 - Various experiment notebooks in `cct_experiments/`
+- `test_mamba_cnn.py` - Example script for the new `MambaCCT` model
 
 ## Project Structure
 
 ```
 EEGCCT/
-├── src/                          # Modular package (recommended)
-│   ├── data/                     # Data processing utilities
-│   ├── models/                   # Model configurations
-│   ├── training/                 # Training utilities
-│   └── utils/                    # Visualization and analysis
+├── utils/                        # Data loading and training helpers
+│   ├── config.py                 # Centralized parameters
+│   ├── data_utils.py             # Loading/augmentation routines
+│   ├── training_utils.py         # Train/test helpers
+│   └── run_training.py           # Example LOSO experiment script
 ├── model/                        # Core model implementations
 ├── notebooks/                    # Jupyter notebook experiments
 ├── data/                         # Raw dataset files

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -4,5 +4,6 @@ from .tiny_eegcct_dw import TinyEEGCCT_DW
 from .mb_performer import MBPerformerEEG
 # from .patch_performer import PatchPerformerEEG  # Temporary commented out due to import issue
 from .stmamba_cct import STMambaCCT, create_stmamba_cct
+from .mamba_cnn import MambaCCT
 
-__all__ = ['CCT', 'MSFAET', 'TinyEEGCCT_DW', 'MBPerformerEEG', 'STMambaCCT', 'create_stmamba_cct']
+__all__ = ['CCT', 'MSFAET', 'TinyEEGCCT_DW', 'MBPerformerEEG', 'STMambaCCT', 'create_stmamba_cct', 'MambaCCT']

--- a/model/mamba_cnn.py
+++ b/model/mamba_cnn.py
@@ -1,0 +1,120 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .cct import Tokenizer
+from .stmamba_cct import MambaBlock
+
+
+class MambaEncoderLayer(nn.Module):
+    """Encoder layer using Mamba block and MLP."""
+    def __init__(self, dim, d_state=16, d_conv=4, expand_factor=2, dropout=0.1):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(dim)
+        self.mamba = MambaBlock(
+            dim=dim,
+            d_state=d_state,
+            d_conv=d_conv,
+            expand_factor=expand_factor,
+        )
+        self.norm2 = nn.LayerNorm(dim)
+        self.mlp = nn.Sequential(
+            nn.Linear(dim, dim * 4),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(dim * 4, dim),
+            nn.Dropout(dropout),
+        )
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x):
+        x = x + self.dropout(self.mamba(self.norm1(x)))
+        x = x + self.dropout(self.mlp(self.norm2(x)))
+        return x
+
+
+class MambaTransformer(nn.Module):
+    """Transformer style stack of Mamba encoder layers."""
+    def __init__(self, dim, num_layers, num_classes, dropout=0.1,
+                 positional_embedding='sine', sequence_length=None,
+                 d_state=16, d_conv=4, expand_factor=2):
+        super().__init__()
+
+        positional_embedding = positional_embedding if positional_embedding in ['sine', 'learnable', 'none'] else 'sine'
+        self.dim = dim
+        self.sequence_length = sequence_length
+
+        assert sequence_length is not None or positional_embedding == 'none', (
+            f"Positional embedding is {positional_embedding} but sequence length not specified")
+
+        self.attention_pool = nn.Linear(dim, 1)
+
+        if positional_embedding != 'none':
+            if positional_embedding == 'learnable':
+                self.positional_emb = nn.Parameter(torch.zeros(1, sequence_length, dim), requires_grad=True)
+            else:
+                self.positional_emb = nn.Parameter(self.sinusoidal_embedding(sequence_length, dim), requires_grad=False)
+        else:
+            self.positional_emb = None
+
+        self.dropout = nn.Dropout(dropout)
+
+        self.blocks = nn.ModuleList([
+            MambaEncoderLayer(dim=dim, d_state=d_state, d_conv=d_conv,
+                               expand_factor=expand_factor, dropout=dropout)
+            for _ in range(num_layers)
+        ])
+        self.norm = nn.LayerNorm(dim)
+        self.fc = nn.Linear(dim, num_classes)
+
+    def forward(self, x):
+        if self.positional_emb is not None:
+            x = x + self.positional_emb
+        x = self.dropout(x)
+        for blk in self.blocks:
+            x = blk(x)
+        x = self.norm(x)
+        x = torch.matmul(F.softmax(self.attention_pool(x), dim=1).transpose(-1, -2), x).squeeze(-2)
+        x = self.fc(x)
+        return x
+
+    @staticmethod
+    def sinusoidal_embedding(n_channels, dim):
+        pe = torch.FloatTensor([[p / (10000 ** (2 * (i // 2) / dim)) for i in range(dim)]
+                                for p in range(n_channels)])
+        pe[:, 0::2] = torch.sin(pe[:, 0::2])
+        pe[:, 1::2] = torch.cos(pe[:, 1::2])
+        return pe.unsqueeze(0)
+
+
+class MambaCCT(nn.Module):
+    """Compact Convolutional Transformer using Mamba blocks."""
+    def __init__(self, kernel_sizes, stride, padding,
+                 pooling_kernel_size, pooling_stride, pooling_padding,
+                 n_conv_layers, n_input_channels, in_planes, activation,
+                 max_pool, conv_bias,
+                 dim, num_layers, num_classes,
+                 dropout=0.1, positional_emb='sine',
+                 d_state=16, d_conv=4, expand_factor=2):
+        super().__init__()
+
+        self.tokenizer = Tokenizer(
+            kernel_sizes=kernel_sizes, stride=stride, padding=padding,
+            pooling_kernel_size=pooling_kernel_size, pooling_stride=pooling_stride, pooling_padding=pooling_padding,
+            n_conv_layers=n_conv_layers, n_input_channels=n_input_channels, n_output_channels=dim,
+            in_planes=in_planes, activation=activation,
+            max_pool=max_pool, conv_bias=conv_bias
+        )
+
+        self.transformer = MambaTransformer(
+            dim=dim, num_layers=num_layers, num_classes=num_classes,
+            dropout=dropout, positional_embedding=positional_emb,
+            sequence_length=self.tokenizer.sequence_length(n_channels=1, height=22, width=1000),
+            d_state=d_state, d_conv=d_conv, expand_factor=expand_factor,
+        )
+
+    def forward(self, x):
+        x = self.tokenizer(x)
+        x = self.transformer(x)
+        return x
+

--- a/test_mamba_cnn.py
+++ b/test_mamba_cnn.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Simple test script for the MambaCCT model"""
+import torch
+import sys
+import os
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+try:
+    from model import MambaCCT
+    print("Successfully imported MambaCCT model")
+except ImportError as e:
+    print("Import error:", e)
+    sys.exit(1)
+
+
+def test_model():
+    """Test the MambaCCT model creation and forward pass"""
+    print("Testing MambaCCT model...")
+
+    try:
+        model = MambaCCT(
+            kernel_sizes=[(22, 1), (1, 24)],
+            stride=(1, 1),
+            padding=(0, 0),
+            pooling_kernel_size=(3, 3),
+            pooling_stride=(1, 1),
+            pooling_padding=(0, 0),
+            n_conv_layers=2,
+            n_input_channels=1,
+            in_planes=64,
+            activation=None,
+            max_pool=False,
+            conv_bias=False,
+            dim=64,
+            num_layers=2,
+            num_classes=4,
+        )
+        print("Model created successfully!")
+    except Exception as e:
+        print("Error creating model:", e)
+        return False
+
+    total_params = sum(p.numel() for p in model.parameters())
+    print("Total parameters:", total_params)
+
+    try:
+        x = torch.randn(2, 1, 22, 1000)
+        print("Input shape:", x.shape)
+        with torch.no_grad():
+            output = model(x)
+        print("Output shape:", output.shape)
+        expected = (2, 4)
+        if output.shape == expected:
+            print("Output shape is correct!")
+            return True
+        else:
+            print("Expected", expected, "got", output.shape)
+            return False
+    except Exception as e:
+        print("Error during forward pass:", e)
+        return False
+
+
+if __name__ == "__main__":
+    success = test_model()
+    if success:
+        print("All tests passed! MambaCCT model is working correctly.")
+    else:
+        print("Tests failed! Please check the model implementation.")
+        sys.exit(1)

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,0 +1,34 @@
+import torch
+
+DATA_DIR = "pickles"
+NUM_SUBJECTS = 9
+
+MODEL_PARAMS = {
+    'kernel_sizes': [(22, 1), (1, 24)],
+    'stride': (1, 1),
+    'padding': (0, 0),
+    'pooling_kernel_size': (3, 3),
+    'pooling_stride': (1, 1),
+    'pooling_padding': (0, 0),
+    'n_conv_layers': 2,
+    'n_input_channels': 1,
+    'in_planes': 64,
+    'activation': None,
+    'max_pool': False,
+    'conv_bias': False,
+    'dim': 64,
+    'num_layers': 2,
+    'num_classes': 2,
+    'dropout': 0.1,
+    'positional_emb': 'learnable',
+}
+
+TRAINING_PARAMS = {
+    'batch_size': 32,
+    'n_epochs': 100,
+    'lr': 3e-5,
+    'b1': 0.9,
+    'b2': 0.999,
+}
+
+DEVICE = torch.device('cuda' if torch.cuda.is_available() else 'cpu')

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -1,0 +1,90 @@
+import glob
+import pickle
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from .config import DEVICE, DATA_DIR, NUM_SUBJECTS
+
+
+def load_data(filename):
+    with open(filename, 'rb') as handle:
+        return pickle.load(handle)
+
+
+def get_source_data(test_sub, val_sub):
+    files = sorted(glob.glob(f"{DATA_DIR}/A*.pkl"))
+    all_data = [load_data(fn) for fn in files]
+
+    test_d = all_data[test_sub]['train']
+    val_d = all_data[val_sub]['train']
+    train_idxs = [i for i in range(NUM_SUBJECTS) if i not in (test_sub, val_sub)]
+    train_ds = [all_data[i]['train'] for i in train_idxs]
+
+    X_train = np.concatenate([d['X'] for d in train_ds], axis=0)
+    y_train = np.concatenate([d['y'] for d in train_ds], axis=0)
+    X_val = val_d['X']
+    y_val = val_d['y']
+    X_test = test_d['X']
+    y_test = test_d['y']
+
+    mask_tr = np.isin(y_train, [0, 1])
+    X_train, y_train = X_train[mask_tr], y_train[mask_tr]
+    mask_val = np.isin(y_val, [0, 1])
+    X_val, y_val = X_val[mask_val], y_val[mask_val]
+    mask_te = np.isin(y_test, [0, 1])
+    X_test, y_test = X_test[mask_te], y_test[mask_te]
+
+    X_train = np.expand_dims(X_train, 1)
+    X_val = np.expand_dims(X_val, 1)
+    X_test = np.expand_dims(X_test, 1)
+
+    idx = np.random.permutation(len(X_train))
+    X_train, y_train = X_train[idx], y_train[idx]
+
+    mu, sigma = X_train.mean(), X_train.std()
+    X_train = (X_train - mu) / sigma
+    X_val = (X_val - mu) / sigma
+    X_test = (X_test - mu) / sigma
+
+    return X_train, y_train, X_val, y_val, X_test, y_test
+
+
+def prepare_dataloaders(X_train, y_train, X_val, y_val, batch_size):
+    train_data = torch.from_numpy(X_train).float().to(DEVICE)
+    train_labels = torch.from_numpy(y_train).long().to(DEVICE)
+    val_data = torch.from_numpy(X_val).float().to(DEVICE)
+    val_labels = torch.from_numpy(y_val).long().to(DEVICE)
+
+    train_dataset = TensorDataset(train_data, train_labels)
+    val_dataset = TensorDataset(val_data, val_labels)
+
+    train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True)
+    val_loader = DataLoader(val_dataset, batch_size=batch_size, shuffle=False)
+    return train_loader, val_loader
+
+
+def augment_data(X, y, batch_size, n_segments=3):
+    n_trials, _, n_ch, n_t = X.shape
+    half = batch_size // 2
+    bounds = [int(round(i * n_t / n_segments)) for i in range(n_segments + 1)]
+
+    aug_data = np.zeros((half, 1, n_ch, n_t), dtype=X.dtype)
+    aug_label = np.zeros(half, dtype=y.dtype)
+    classes = [0, 1]
+
+    for i in range(half):
+        lbl = np.random.choice(classes)
+        aug_label[i] = lbl
+        idxs = np.where(y == lbl)[0]
+        picks = np.random.choice(idxs, size=n_segments, replace=True)
+        segments = []
+        for s in range(n_segments):
+            st, ed = bounds[s], bounds[s + 1]
+            segments.append(X[picks[s], 0, :, st:ed])
+        new_trial = np.concatenate(segments, axis=-1)
+        aug_data[i, 0] = new_trial
+
+    tdata = torch.from_numpy(aug_data).float().to(DEVICE)
+    tlabels = torch.from_numpy(aug_label).long().to(DEVICE)
+    return tdata, tlabels

--- a/utils/run_training.py
+++ b/utils/run_training.py
@@ -1,0 +1,57 @@
+import time
+import random
+import numpy as np
+import torch
+import pandas as pd
+from torch import optim, nn
+
+from .config import MODEL_PARAMS, TRAINING_PARAMS, NUM_SUBJECTS, DEVICE
+from .data_utils import get_source_data, prepare_dataloaders
+from .training_utils import EarlyStopping, train_model, test_model
+from model import MambaCCT
+
+
+def main():
+    results_df = pd.DataFrame(columns=['Test Subject', 'Val Subject', 'Test Acc', 'Seed'])
+    all_test_accuracies = []
+    all_test_losses = []
+
+    for test_sub in range(NUM_SUBJECTS):
+        start_time = time.time()
+        seed_n = np.random.randint(2021)
+        print('seed is', seed_n)
+        random.seed(seed_n)
+        np.random.seed(seed_n)
+        torch.manual_seed(seed_n)
+        torch.cuda.manual_seed_all(seed_n)
+
+        val_sub = (test_sub + 1) % NUM_SUBJECTS
+        print(f"Val Subject {val_sub + 1}:")
+        model = MambaCCT(**MODEL_PARAMS).to(DEVICE)
+        loss_fn = nn.CrossEntropyLoss().to(DEVICE)
+        optimizer = optim.Adam(model.parameters(), lr=TRAINING_PARAMS['lr'], betas=(TRAINING_PARAMS['b1'], TRAINING_PARAMS['b2']))
+
+        X_train, y_train, X_val, y_val, X_test, y_test = get_source_data(test_sub, val_sub)
+        train_loader, val_loader = prepare_dataloaders(X_train, y_train, X_val, y_val, TRAINING_PARAMS['batch_size'])
+        test_loader = prepare_dataloaders(X_test, y_test, X_test, y_test, TRAINING_PARAMS['batch_size'])[1]
+
+        early_stopping = EarlyStopping(patience=10, min_delta=0.01)
+        trained_model, *_ = train_model(model, optimizer, loss_fn, train_loader, val_loader, TRAINING_PARAMS, X_train, y_train, early_stopping)
+
+        test_accuracy, test_loss = test_model(trained_model, loss_fn, test_loader)
+        all_test_accuracies.append(test_accuracy)
+        all_test_losses.append(test_loss)
+
+        time_elapsed = time.time() - start_time
+        print(f"Training complete in {time_elapsed // 60:.0f}m {time_elapsed % 60:.0f}s")
+        results_df.loc[len(results_df)] = {'Test Subject': test_sub + 1, 'Val Subject': val_sub + 1, 'Test Acc': test_accuracy, 'Seed': seed_n}
+
+    avg_acc = np.mean(all_test_accuracies)
+    avg_loss = np.mean(all_test_losses)
+    print(f"Average Test Accuracy: {avg_acc:.2f}%")
+    print(f"Average Test Loss: {avg_loss:.4f}")
+    print(results_df)
+
+
+if __name__ == '__main__':
+    main()

--- a/utils/training_utils.py
+++ b/utils/training_utils.py
@@ -1,0 +1,88 @@
+import torch
+from .data_utils import augment_data
+
+
+class EarlyStopping:
+    def __init__(self, patience=7, min_delta=0.0):
+        self.patience = patience
+        self.min_delta = min_delta
+        self.counter = 0
+        self.best_score = None
+        self.early_stop = False
+
+    def __call__(self, val_loss, model):
+        score = -val_loss
+        if self.best_score is None:
+            self.best_score = score
+        elif score < self.best_score + self.min_delta:
+            self.counter += 1
+            if self.counter >= self.patience:
+                self.early_stop = True
+        else:
+            self.best_score = score
+            self.counter = 0
+
+
+def train_model(model, optimizer, loss_fn, train_loader, val_loader, params, X_train, y_train, early_stopping):
+    train_losses, val_losses, val_accuracies = [], [], []
+    for epoch in range(params['n_epochs']):
+        model.train()
+        train_loss = 0.0
+        for images, labels in train_loader:
+            aug_images, aug_labels = augment_data(X_train, y_train, params['batch_size'])
+            images = torch.cat((images, aug_images))
+            labels = torch.cat((labels, aug_labels))
+            outputs = model(images)
+            loss = loss_fn(outputs, labels)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            train_loss += loss.item()
+
+        val_loss = 0.0
+        model.eval()
+        correct = 0
+        total = 0
+        with torch.no_grad():
+            for images, labels in val_loader:
+                outputs = model(images)
+                loss = loss_fn(outputs, labels)
+                val_loss += loss.item()
+                _, predicted = torch.max(outputs.data, 1)
+                total += labels.size(0)
+                correct += (predicted == labels).sum().item()
+
+        train_loss = train_loss / len(train_loader)
+        val_loss = val_loss / len(val_loader)
+        val_accuracy = 100 * correct / total
+        print(f"Epoch {epoch+1}: Train Loss {train_loss:.4f}, Val Acc {val_accuracy:.2f}%")
+
+        train_losses.append(train_loss)
+        val_losses.append(val_loss)
+        val_accuracies.append(val_accuracy)
+
+        early_stopping(val_loss, model)
+        if early_stopping.early_stop:
+            print("Early stopping")
+            break
+    return model, train_losses, val_losses, val_accuracies
+
+
+def test_model(model, loss_fn, test_loader):
+    model.eval()
+    test_loss = 0.0
+    correct = 0
+    total = 0
+    with torch.no_grad():
+        for images, labels in test_loader:
+            outputs = model(images)
+            loss = loss_fn(outputs, labels)
+            test_loss += loss.item()
+            _, predicted = torch.max(outputs.data, 1)
+            total += labels.size(0)
+            correct += (predicted == labels).sum().item()
+
+    test_loss /= len(test_loader)
+    test_accuracy = 100 * correct / total
+    print(f"Test Loss: {test_loss:.4f}, Test Acc: {test_accuracy:.2f}%")
+    return test_accuracy, test_loss


### PR DESCRIPTION
## Summary
- refactor augmentation notebook into reusable Python modules under `utils`
- add `config.py` for model and training parameters
- implement data utilities and training helpers
- provide `run_training.py` script to execute LOSO experiments
- document new `utils/` folder layout in README

## Testing
- `python -m py_compile utils/*.py model/mamba_cnn.py test_mamba_cnn.py`
- `python test_mamba_cnn.py` *(fails: ModuleNotFoundError: No module named 'torch')*
- `conda activate eegcct` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f3e4a81308330a2a47a31df1040d6