### PR TITLE
Add CLI options to run_mamba

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Run a single-subject experiment:
 python run_mamba_example.py --test-subject 0 --val-subject 1
 ```
 
+To run all nine folds of LOSO evaluation:
+
+```bash
+python run_mamba.py --loso
+```
+
 For a full leave-one-subject-out evaluation across all subjects:
 
 ```bash
@@ -73,6 +79,7 @@ EEGCCT/
 ├── model/                        # Core model implementations
 ├── notebooks/                    # Jupyter notebook experiments
 ├── run_mamba_example.py          # Single-subject training example
+├── run_mamba.py                  # Command line training wrapper
 ├── data/                         # Raw dataset files
 ├── pickles/                      # Preprocessed data
 ├── example_usage.py              # Usage examples

--- a/run_mamba.py
+++ b/run_mamba.py
@@ -1,0 +1,174 @@
+"""Run leave-one-subject-out evaluation for the MambaCCT model.
+
+This script mirrors the training routine used in ``notebooks/cct`` but can be
+executed from the command line. It loads the preprocessed EEG data via the
+``utils`` package and trains the :class:`MambaCCT` model for each subject in
+turn.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import random
+import time
+
+import numpy as np
+import pandas as pd
+import torch
+from torch import nn, optim
+
+from utils.config import MODEL_PARAMS, TRAINING_PARAMS, NUM_SUBJECTS, DEVICE
+from utils.data_utils import get_source_data, prepare_dataloaders
+from utils.training_utils import EarlyStopping, train_model, test_model
+from model import MambaCCT
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def run_single_fold(test_subject: int, val_subject: int, seed: int) -> tuple[float, float]:
+    """Train and evaluate one fold.
+
+    Parameters
+    ----------
+    test_subject : int
+        Index of the subject held out for testing (0-based).
+    val_subject : int
+        Index of the subject used for validation.
+    seed : int
+        Random seed for reproducibility.
+    """
+
+    logger.info(
+        "Running fold: test_subject=%d, val_subject=%d, seed=%d",
+        test_subject,
+        val_subject,
+        seed,
+    )
+
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+    # Prepare data
+    X_train, y_train, X_val, y_val, X_test, y_test = get_source_data(test_subject, val_subject)
+    train_loader, val_loader = prepare_dataloaders(
+        X_train, y_train, X_val, y_val, TRAINING_PARAMS["batch_size"]
+    )
+    test_loader = prepare_dataloaders(
+        X_test, y_test, X_test, y_test, TRAINING_PARAMS["batch_size"]
+    )[1]
+
+    # Model, loss and optimizer
+    model = MambaCCT(**MODEL_PARAMS).to(DEVICE)
+    loss_fn = nn.CrossEntropyLoss().to(DEVICE)
+    optimizer = optim.Adam(
+        model.parameters(),
+        lr=TRAINING_PARAMS["lr"],
+        betas=(TRAINING_PARAMS["b1"], TRAINING_PARAMS["b2"]),
+    )
+
+    early_stopping = EarlyStopping(patience=10, min_delta=0.01)
+    trained_model, *_ = train_model(
+        model,
+        optimizer,
+        loss_fn,
+        train_loader,
+        val_loader,
+        TRAINING_PARAMS,
+        X_train,
+        y_train,
+        early_stopping,
+    )
+
+    test_accuracy, test_loss = test_model(trained_model, loss_fn, test_loader)
+    logger.info("Fold result - accuracy: %.2f%%, loss: %.4f", test_accuracy, test_loss)
+
+    return test_accuracy, test_loss
+
+
+def run_loso(seed: int | None = None) -> list[dict[str, float]]:
+    """Run LOSO evaluation across all subjects.
+
+    Parameters
+    ----------
+    seed : int | None
+        Base random seed. Each fold will add the test subject index to
+        this value. When ``None``, a new random seed will be drawn for
+        every fold.
+    """
+
+    results: list[dict[str, float]] = []
+    accs: list[float] = []
+    losses: list[float] = []
+
+    for test_sub in range(NUM_SUBJECTS):
+        start_time = time.time()
+        fold_seed = np.random.randint(2021) if seed is None else seed + test_sub
+        val_sub = (test_sub + 1) % NUM_SUBJECTS
+
+        acc, loss = run_single_fold(test_sub, val_sub, fold_seed)
+        accs.append(acc)
+        losses.append(loss)
+
+        elapsed = time.time() - start_time
+        logger.info("Fold %d finished in %dm %ds", test_sub + 1, int(elapsed // 60), int(elapsed % 60))
+
+        results.append(
+            {
+                "Test Subject": test_sub + 1,
+                "Val Subject": val_sub + 1,
+                "Test Acc": acc,
+                "Seed": fold_seed,
+            }
+        )
+        logger.info("======================================")
+
+    avg_acc = np.mean(accs)
+    avg_loss = np.mean(losses)
+    logger.info("Average Test Accuracy: %.2f%%", avg_acc)
+    logger.info("Average Test Loss: %.4f", avg_loss)
+    logger.info("\n%s", pd.DataFrame(results))
+
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Train MambaCCT on one split or run LOSO evaluation"
+    )
+    parser.add_argument(
+        "--test-subject",
+        type=int,
+        default=0,
+        help="index of subject used for testing",
+    )
+    parser.add_argument(
+        "--val-subject",
+        type=int,
+        default=1,
+        help="index of subject used for validation",
+    )
+    parser.add_argument("--seed", type=int, default=42, help="random seed")
+    parser.add_argument(
+        "--loso",
+        action="store_true",
+        help="run leave-one-subject-out evaluation",
+    )
+    args = parser.parse_args()
+
+    if args.loso:
+        run_loso(args.seed)
+    else:
+        run_single_fold(args.test_subject, args.val_subject, args.seed)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/run_mamba_example.py
+++ b/run_mamba_example.py
@@ -8,14 +8,22 @@ You can specify the test/validation subject as command line arguments.
 
 import argparse
 import random
+import logging
 import numpy as np
 import torch
 from torch import nn, optim
 
-from utils.config import MODEL_PARAMS, TRAINING_PARAMS, DEVICE
+from utils.config import MODEL_PARAMS, TRAINING_PARAMS, DEVICE, NUM_SUBJECTS
 from utils.data_utils import get_source_data, prepare_dataloaders
 from utils.training_utils import EarlyStopping, train_model, test_model
 from model import MambaCCT
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
 
 
 def main(test_subject: int = 0, val_subject: int = 1, seed: int = 42):
@@ -30,13 +38,18 @@ def main(test_subject: int = 0, val_subject: int = 1, seed: int = 42):
     seed : int, default=42
         Random seed for reproducibility.
     """
+    logger.info(
+        f"Starting run: test_subject={test_subject}, val_subject={val_subject}, seed={seed}"
+    )
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
     torch.cuda.manual_seed_all(seed)
 
     # Load data
-    X_train, y_train, X_val, y_val, X_test, y_test = get_source_data(test_subject, val_subject)
+    X_train, y_train, X_val, y_val, X_test, y_test = get_source_data(
+        test_subject, val_subject
+    )
     train_loader, val_loader = prepare_dataloaders(
         X_train, y_train, X_val, y_val, TRAINING_PARAMS['batch_size']
     )
@@ -62,17 +75,45 @@ def main(test_subject: int = 0, val_subject: int = 1, seed: int = 42):
 
     # Evaluate
     test_accuracy, test_loss = test_model(trained_model, loss_fn, test_loader)
-    print(f"Final Test Accuracy: {test_accuracy:.2f}%")
-    print(f"Final Test Loss: {test_loss:.4f}")
+    logger.info(f"Final Test Accuracy: {test_accuracy:.2f}%")
+    logger.info(f"Final Test Loss: {test_loss:.4f}")
+
+    return test_accuracy, test_loss
+
+
+def run_loso(seed: int = 42):
+    """Run leave-one-subject-out evaluation over all subjects."""
+    all_acc = []
+    all_loss = []
+
+    for test_sub in range(NUM_SUBJECTS):
+        val_sub = (test_sub + 1) % NUM_SUBJECTS
+        current_seed = np.random.randint(2021)
+        logger.info(
+            f"LOSO fold -- test_subject={test_sub}, val_subject={val_sub}, seed={current_seed}"
+        )
+        acc, loss = main(test_sub, val_sub, current_seed)
+        all_acc.append(acc)
+        all_loss.append(loss)
+
+    avg_acc = np.mean(all_acc)
+    avg_loss = np.mean(all_loss)
+    logger.info(f"Average Test Accuracy: {avg_acc:.2f}%")
+    logger.info(f"Average Test Loss: {avg_loss:.4f}")
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Train MambaCCT on one split")
+    parser = argparse.ArgumentParser(description="Train MambaCCT on one split or run LOSO evaluation")
     parser.add_argument("--test-subject", type=int, default=0,
                         help="index of subject used for testing")
     parser.add_argument("--val-subject", type=int, default=1,
                         help="index of subject used for validation")
     parser.add_argument("--seed", type=int, default=42, help="random seed")
+    parser.add_argument("--loso", action="store_true",
+                        help="run leave-one-subject-out evaluation")
     args = parser.parse_args()
 
-    main(args.test_subject, args.val_subject, args.seed)
+    if args.loso:
+        run_loso(args.seed)
+    else:
+        main(args.test_subject, args.val_subject, args.seed)


### PR DESCRIPTION
## Summary
- update `run_mamba.py` with the same command line options as used in the notebooks
- document that LOSO evaluation now requires the `--loso` flag

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch torchvision torchaudio -i https://download.pytorch.org/whl/cpu/cp311/torch_stable.html` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6882f457ebd08330b177c636dd222e2f